### PR TITLE
Display hint if no airdate is available

### DIFF
--- a/src/scenes/manage/searchresult/SearchResult.tsx
+++ b/src/scenes/manage/searchresult/SearchResult.tsx
@@ -57,6 +57,7 @@ export default class SearchResult extends Component<Props, State> {
 
     render() {
         const { series } = this.props
+        const firstAirDate = series.first_air_date.length > 0 ? TimeUtil.formatDateString(series.first_air_date) : "n/a"
 
         return (
             <div className="series-result">
@@ -64,7 +65,7 @@ export default class SearchResult extends Component<Props, State> {
                 <div className="series-title-wrapper">
                     <div className="series-title">{series.name}</div>
                 </div>
-                <div className="airing">{TimeUtil.formatDateString(series.first_air_date)}</div>
+                <div className="airing">{firstAirDate}</div>
                 <div className="actions">
                     {this.actions}
                 </div>


### PR DESCRIPTION
Habe ein bisschen bei dir in der VCR Anwendung rumgespielt und gesehen, dass es nicht abgefangen wird, falls du in der Response keinen timestamp erhältst. 

Kann man bestimmt eleganter lösen, allerdings ist der Key so wie ich das sehe eh immer gesetzt. Value ist dann halt ein leerer String: `"first_air_date":""`

Das sollte es beheben. Habe es nicht getestet. 